### PR TITLE
GOCIA w/ Cluster Sampling Mutation Added 

### DIFF
--- a/gocia/geom/build.py
+++ b/gocia/geom/build.py
@@ -129,6 +129,12 @@ def grow_frag(
     for fragName in growList:
         if fragName == 'CO':
             frags_to_add.append(Atoms('CO',[(0, 0, 0),(0, 0, 1.15034)]))
+         elif fragName == 'O':
+            frags_to_add.append(Atoms('O',[(0,0,0)]))
+        elif fragName == 'Rh':
+            frags_to_add.append(Atoms('Rh',[(0,0,0)]))
+        elif fragName == 'Ti':
+            frags_to_add.append(Atoms('Ti',[(0,0,0)]))
         elif fragName == 'H':
             frags_to_add.append(Atoms('H',[(0,0,0)]))
         elif fragName =='H2O':
@@ -211,6 +217,9 @@ def grow_frag(
                 #print(i, tmpInterfc.get_pos()[i])
                 n_place += 1
                 #print(coord, xLim, yLim, zLim, geom.is_withinPosLim(coord, xLim, yLim, zLim))
+                if n_place == 10000:
+                    print('Dead Loop located line 223 in build.py -> change zLim!!')
+                    print(f'Your zLim={zLim} ... coord={coord}')
 
             # Might want to use other way to randomly rotate positiosn
             #fragAtms.rotate(random.random()*np.pi/2,geom.rand_direction(),center=(0,0,0))
@@ -386,6 +395,12 @@ def boxSample_frag(
             frags_to_add.append(Atoms('CO',[(0, 0, 0),(0, 0, 1.15034)]))
         elif fragName == 'H':
             frags_to_add.append(Atoms('H',[(0,0,0)]))
+        elif fragName == 'O':
+            frags_to_add.append(Atoms('O',[(0,0,0)]))
+        elif fragName == 'Rh':
+            frags_to_add.append(Atoms('Rh',[(0,0,0)]))
+        elif fragName == 'Ti':
+            frags_to_add.append(Atoms('Ti',[(0,0,0)]))
         elif fragName =='H2O':
             frags_to_add.append(Atoms('OH2',[(0,0,0),(0.758602,0,0.504284),(-0.758602,0,0.504284)]))
         elif fragName == 'HO':

--- a/gocia/geom/build.py
+++ b/gocia/geom/build.py
@@ -129,7 +129,7 @@ def grow_frag(
     for fragName in growList:
         if fragName == 'CO':
             frags_to_add.append(Atoms('CO',[(0, 0, 0),(0, 0, 1.15034)]))
-         elif fragName == 'O':
+        elif fragName == 'O':
             frags_to_add.append(Atoms('O',[(0,0,0)]))
         elif fragName == 'Rh':
             frags_to_add.append(Atoms('Rh',[(0,0,0)]))

--- a/gocia/interface.py
+++ b/gocia/interface.py
@@ -840,7 +840,7 @@ class Interface:
         )
         self.set_allAtoms(tmpInterfc.get_allAtoms())
 
-    def growMut_frag(self, fragPool,bondRejList=None):
+    def growMut_frag(self, fragPool, bondRejList=None, growProb=None):
         print(' |- Growth mutation:', end = '\t')
         from gocia.geom.build import grow_frag
         tmpInterfc = self.copy()

--- a/gocia/interface.py
+++ b/gocia/interface.py
@@ -844,7 +844,13 @@ class Interface:
         print(' |- Growth mutation:', end = '\t')
         from gocia.geom.build import grow_frag
         tmpInterfc = self.copy()
-        myFrag = np.random.choice(fragPool, size=1)[0]
+        
+        # Pick the fragment to grow
+        if growProb == None:
+            myFrag = np.random.choice(fragPool, size=1)[0]
+        else:
+            myFrag = np.random.choice(fragPool, size=1, p=growProb)[0]
+        
         print(myFrag, end='\t')
         tmpInterfc = grow_frag(
             tmpInterfc,


### PR DESCRIPTION
Here is my GOCIA repository with a mutation added to the gen_offspring_box() object in the popGrandCanonPoly.py script as well as some supporting functions to the Interface.py script.

To the Interface.py script, the 'clusterAtoms' attribute is added to Interface class. Two functions are added to the Interface.py script, get_clusterList() and get_cluster_fragList() which obtains the indices of the cluster atoms and frags attached to the cluster, respectively.

To the gen_offspring_box() object, the 'move cluster' mutation is added which is built to mimic the preexisting 'move' mutation, but instead of a single fragment, all atoms gathered by the get_cluster_fragList() function are moved as a whole along the surface.